### PR TITLE
0.1.1: better build system, switch to cxxopts and C++17, and better ux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 .vscode/
 releases/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 bin/
 .vscode/
-build/
+releases/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.24)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-project(itfl VERSION 0.1.0)
+project(itfl VERSION 0.1.2)
 
 add_executable(itfl src/itfl.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.24)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(itfl VERSION 0.1.0)
+
+add_executable(itfl src/itfl.cpp)
+
+target_include_directories(itfl PUBLIC
+    ${CMAKE_SOURCE_DIR}/lib
+)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Written in C++.
 
 ## Features
 - __Fast Hashing__: Efficiently processes files of any size, thanks to the amazing single-header library [picosha2](https://github.com/okdshin/PicoSHA2 "picosha2.h") by [okdshin](https://github.com/okdshin)!
-- __Simple By Design:__: Clean, single-purpose CLI tool that does one thing, and does it well.
+- __Simple:__: Clean, single-purpose CLI tool that does one thing, and does it well.
 - __No Dependencies__: No external libs required to compile and run.
 
 ## Installation
@@ -37,29 +37,14 @@ I'll put out binaries for Linux for every major release :) x86_64 only.
 ## Usage
 
 ```bash
-itfl <filename> <expected-sha256-hash>
+itfl <filename> <expected-sha256-hash> <-v>
 ```
 
 ### Arguments:
 - ```filename``` : relative or absolute path to the file you want to verify
 - ```expected-sha256-hash``` : SHA-256 hex string to check against
+- ```-v``` : verbose flag; print out both computed and provided hash
 
-### Successful Check:
-```bash
-$ itfl ./installer.zip e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-
-Calculated SHA-256 hash of ./installer.zip: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-Given hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-FILE IS LEGIT!
-```
-### Failed Check:
-```bash
-$ itfl ./installer.zip e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-
-Calculated SHA-256 hash of ./installer.zip: f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2
-Given hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-HASH CHECK FAILED!
-```
 ## Contributing
 
 Contributions are welcome. Please fork the repo and use a feature branch if you wish to do so! Pull requests are welcome, too.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Written in C++.
 ## Installation
 ### From Source
 ### Prerequisites:
-- A C++11 compliant compiler (gcc, clang, MSVC etc.)
+- A C++17 compliant compiler (gcc, clang, MSVC etc.)
 - Git
 
 ```bash
@@ -23,7 +23,7 @@ git clone https://github.com/your-username/itfl.git
 cd itfl
 
 # Compile
-g++ -std=c++11 -O3 -o itfl src/itfl.cpp
+g++ -std=c++17 -O3 -o itfl src/itfl.cpp
 
 # Optional: Move into PATH for easy usage
 # For Linux/macOS:


### PR DESCRIPTION
Switched to cxxopts for better argument parsing and handling, which can scale to more flags. Switched to Cmake for easier building, and updated the help and error outputs.
Also updated the standard to be C++17 so more modern language features can be used in the future, as it's easier to do now when the project is young.